### PR TITLE
Quick fix for name variable being empty in the groups controller.

### DIFF
--- a/application/controllers/groups.php
+++ b/application/controllers/groups.php
@@ -68,6 +68,9 @@ class Groups extends CI_Controller {
 	    // # Setup Email library to email invites for the group
 	    $this->load->helper('email');
 	    $this->load->library('email');
+
+	    // Set the group name variable
+	    $name = $this->input->post('name');
 	    
 	    // Create an array of the email addresses
 	    $invites=array();


### PR DESCRIPTION
Quick fix for the code igniter error when trying to add a group on live.
