### PR TITLE
using is_readable as a permissions check, fix for #86

### DIFF
--- a/index.php
+++ b/index.php
@@ -41,9 +41,7 @@ if(file_exists($appDir)){
 const UNMARK_ENV_CONFIG_GLOBAL = '/etc/unmark/environment.php';
 if(!defined('ENVIRONMENT')){
 	if (is_readable(UNMARK_ENV_CONFIG_GLOBAL)) {
-		if(file_exists(UNMARK_ENV_CONFIG_GLOBAL)){
-	        include_once(UNMARK_ENV_CONFIG_GLOBAL);
-	    }
+	    include_once(UNMARK_ENV_CONFIG_GLOBAL);
 	}
 }
 if(!defined('ENVIRONMENT')){

--- a/index.php
+++ b/index.php
@@ -36,18 +36,15 @@ if(file_exists($appDir)){
         include_once($localEnvConfigFile);
     }
 }
+
 // Looking for global environment configuration under /etc/unmark/environment.php
 const UNMARK_ENV_CONFIG_GLOBAL = '/etc/unmark/environment.php';
 if(!defined('ENVIRONMENT')){
-	try {
-		if(!file_exists(UNMARK_ENV_CONFIG_GLOBAL)){
-	        // 1.6 Error trying to locate environment file. This is no big deal as you likely do not need it. See FAQ to address this issue.
-	    } else {
-	    	include_once(UNMARK_ENV_CONFIG_GLOBAL);
+	if (is_readable(UNMARK_ENV_CONFIG_GLOBAL)) {
+		if(file_exists(UNMARK_ENV_CONFIG_GLOBAL)){
+	        include_once(UNMARK_ENV_CONFIG_GLOBAL);
 	    }
-    } catch(Exception $e) {
-        // 1.6 Error trying to locate environment file. This is no big deal as you likely do not need it. See FAQ to address this issue.
-    }
+	}
 }
 if(!defined('ENVIRONMENT')){
     define('ENVIRONMENT', 'production');


### PR DESCRIPTION
Addresses the open_basedir restriction as we do a file permissions checking using "is_readable". Removed the try catch from the global environment config logic as it didn't throw any exceptions and wasn't needed.

Addresses issue: #86 